### PR TITLE
add option to search for exact same query instead of the one suggested by google

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ var options = {
     filter : 0,
     pws : 0
   },
+  exactQuery: true,
   num : 100
 };
 
@@ -33,6 +34,7 @@ const links = await serp.search(options);
 - For google.com, the param host is not necessary.
 - qs can contain the usual Google search parameters : https://moz.com/ugc/the-ultimate-guide-to-the-google-search-parameters.
 - options.qs.q is the keyword
+- set exactQuery to true if you want only the results for your exact query, instead of suggested results by google
 - num is the number of desired results (defaut is 10).
 - The options object can also contain all request options like http headers, ... . SERP is using the request module :  https://github.com/request/request
 - The user agent is not mandatory. Default value will be : 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1'

--- a/index.js
+++ b/index.js
@@ -168,7 +168,7 @@ function getNumberOfResults(options, response) {
   * @returns {Array} The list of the links
   */
 async function getLinks(options, response, nbrOfLinks) {
-  const result = extractLinks(response.body);
+  const result = extractLinks(options, response.body);
   let allLinks = result.links;
 
   if (allLinks.length === 0) {
@@ -195,13 +195,23 @@ async function getLinks(options, response, nbrOfLinks) {
 /**
  * extractLinks - Get the links from the HTML body
  *
+ * @param {Json} options The search options
  * @param  {type} body th HTML body
  * @returns {Object} The list of the links & information about the next SERP page
  */
-function extractLinks(body) {
+function extractLinks(options, body) {
   const links = [];
 
   const $ = cheerio.load(body);
+
+  // if exactQuery option is present then
+  // check if the result is exactly for the provided query
+  // if it is for some modified/suggested query, return empty array
+  if (options.exactQuery) {
+    let query = options.qs.q;
+    let a = $(`div:contains(No results found for ${query})`).text().includes(`No results found for ${query}`);
+    if (a) return { links };
+  }
 
   // Get the links matching to the web sites
   // Update May 2020 : search only the h3. Google changes its CSS name


### PR DESCRIPTION
This pull request fixes this issue #9 
**What it does:**
if  `exactQuery: true` is set,
it checks if the response contains `No results found for ${query}`
If yes, then return empty array.

with `exactQuery: false`

![Screenshot (99)](https://user-images.githubusercontent.com/16982615/84105358-b0895400-aa35-11ea-9f59-d6760a7ce45f.png)

with `exactQuery: true`

![Screenshot (100)](https://user-images.githubusercontent.com/16982615/84105373-bf700680-aa35-11ea-8bbb-5a3b56b02e71.png)

The behavior is as expected now.